### PR TITLE
Add an onTransitionExecuteTransition for security requirements

### DIFF
--- a/.cards/local/calculations/securityRequirement.lp
+++ b/.cards/local/calculations/securityRequirement.lp
@@ -23,3 +23,8 @@ policyCheckFailure(
         not field(Card, "workflowState", "Closed as rejected"),
         parent(ReviewTask, Card),
         not field(ReviewTask, "workflowState", "Closed as done").
+
+onTransitionExecuteTransition(Requirement, "Reopen", ReviewTask, "Reopen") :-
+    field(Requirement, "cardType", "secdeva/cardTypes/requirement"),
+    parent(ReviewTask, Requirement),
+    field(ReviewTask, "cardType", "base/cardTypes/task").


### PR DESCRIPTION
Reopen review subtasks if a security requirement is reopened